### PR TITLE
Fix German spelling of "Deutsch"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following languages of audio alerts are currently supported:
 | --------- | :---------- | :--- |
 | عربى      | Arabic      | ar   |
 | বাংলা     | Bengali     | bn   |
-| Deutsche  | German      | de   |
+| Deutsch  | German      | de   |
 | English   | English     | en   |
 | Español   | Spanish     | es   |
 | Français  | French      | fr   |


### PR DESCRIPTION
Not a significant change but something I noticed. 
